### PR TITLE
Use Eris.Message as message type in requirements

### DIFF
--- a/src/Command.ts
+++ b/src/Command.ts
@@ -44,7 +44,7 @@ export interface CommandRequirements {
 	// TODO: use a union of all the string literals we could possibly put here
 	permissions?: string | string[];
 	/** A custom function that must return true to enable the command. */
-	custom?(msg: object, args: string[], ctx: CommandContext): boolean | Promise<boolean>;
+	custom?(msg: Eris.Message, args: string[], ctx: CommandContext): boolean | Promise<boolean>;
 }
 
 /** An object containing context information for processing a command. */


### PR DESCRIPTION
The type of the `message` argument to custom requirement functions should be `Eris.Message`, not just `object`.