### PR TITLE
Add invalidCommand emit

### DIFF
--- a/src/Client.ts
+++ b/src/Client.ts
@@ -158,12 +158,16 @@ export class Client extends Eris.Client implements ClientOptions {
 		const commandName = args.shift();
 		if (commandName === undefined) return;
 		const command = this.commandForName(commandName);
-		if (!command) return;
 		// Construct a full context object now that we have all the info
 		const fullContext: CommandContext = Object.assign({
 			prefix,
 			commandName,
 		}, partialContext);
+		// If the message has command but that command is not found
+		if (!command) {
+			this.emit('invalidCommand', msg, args, fullContext);
+			return;
+		}
 		// Do the things
 		this.emit('preCommand', command, msg, args, fullContext);
 		const executed = await command.execute(msg, args, fullContext);

--- a/src/Client.ts
+++ b/src/Client.ts
@@ -349,6 +349,15 @@ export declare interface Client extends Eris.Client {
 	 * @param context The context object for the command
 	 */
 	on(event: 'preCommand', listener: (cmd: Command, msg: Eris.Message, args: string[], ctx: CommandContext) => void): this;
+	/**
+	 * @event
+	 * Fired if a message starts with a command but no valid command is found
+	 * @param command The command that will be executed
+	 * @param message The message that triggered the command
+	 * @param args The arguments passed to the command handler
+	 * @param context The context object for the command
+	 */
+	on(event: 'invalidCommand', listener: (msg: Eris.Message, args: string[], ctx: CommandContext) => void): this;
 }
 
 // Added event definitions


### PR DESCRIPTION
This PR adds the ability to run a custom handler when a user tries using a command but that command name is not found. 

Should close #27 