### PR TITLE
add a prepack script

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     "docs": "typedoc src --out docs/docs --theme minimal",
     "lint": "eslint src/**/*.ts",
     "lint-fix": "eslint --fix src/**/*.ts",
-    "prepublishOnly": "eslint src/**/*.ts && tsc"
+    "prepublishOnly": "eslint src/**/*.ts && tsc",
+    "prepack": "tsc"
   },
   "repository": "Geo1088/yuuko",
   "author": "Geo1088 <georgej1088@gmail.com>",


### PR DESCRIPTION
This PR adds a prepack script that will run `tsc` whenever someone installs this package. Currently, when you install a branch or a fork you will get errors because it will not compile on install. The only way to use Yuuko at the moment is to use the stable version from NPM. This PR opens up a lot more possibilities.