### PR TITLE
Better eval

### DIFF
--- a/src/commands/debug.ts
+++ b/src/commands/debug.ts
@@ -30,8 +30,14 @@ export default new Command('debug', async function debug (msg, args, ctx) {
 	};
 	// eslint-disable-next-line no-multi-assign
 	console.log = console.error = console.warn = console.info = console._logger.bind(console);
-	// eslint-disable-next-line
-	const c = console; // Convenience
+
+	// Convenience variables exposed to eval
+	/* eslint-disable */
+	const c = console;
+	const message = msg;
+	const context = ctx;
+	const {client, prefix, commandName} = ctx;
+	/* eslint-enable */
 
 	// Eval the things and send the results
 	let result;
@@ -40,12 +46,12 @@ export default new Command('debug', async function debug (msg, args, ctx) {
 	} catch (e) {
 		result = e;
 	}
-	const message = `\`\`\`js\n${console._formatLines()}${util.inspect(result, inspectOptions)}\n\`\`\``;
+	const outputText = `\`\`\`js\n${console._formatLines()}${util.inspect(result, inspectOptions)}\n\`\`\``;
 
 	// Send the message
 	let outputMsg;
 	try {
-		outputMsg = await msg.channel.createMessage(message);
+		outputMsg = await msg.channel.createMessage(outputText);
 	} catch (err) {
 		try {
 			msg.channel.createMessage(`Error sending message:\n\`\`\`\n${err}\n\`\`\``);

--- a/src/commands/debug.ts
+++ b/src/commands/debug.ts
@@ -16,6 +16,9 @@ export default new Command('debug', async function debug (msg, args, ctx) {
 		if (string.startsWith('js')) {
 			string = string.substr(2);
 		}
+		if (string.startsWith('javascript')) {
+			string = string.substr(10);
+		}
 	}
 
 	// Create a dummy console object


### PR DESCRIPTION
Adds some more convenience variables to `eval` context and accepts ```` ```javascript ``` ```` code blocks in addition to ```` ``` ``` ```` and ```` ```js ``` ````.