### PR TITLE
Add underscored docs files to Jekyll `include`

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -41,7 +41,7 @@ jobs:
 
           # Add generated files that start with underscores to Jekyll `include`
           cd .temp
-          UNDERSCORE_FILES=(docs/**/_*)
+          UNDERSCORE_FILES=(docs/$TAG_NAME/**/_*)
           for file in "$UNDERSCORES_FILE[@]"; do
             # `include` is the last item of the config file, so we just append
             echo "- '$file'" >> .config.yml

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -50,7 +50,7 @@ jobs:
           # Commit to the gh-pages branch
           git config user.name "Build Bot"
           git config user.email "bot@github-actions"
-          git add docs _data
+          git add docs _data _config.yml
           git commit -m "Documentation for tag $TAG_NAME" -m "Generated from commit ${GITHUB_SHA:0:7}"
 
           # Convert remote URL from HTTPS to SSH format so we can use our deploy key

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -39,8 +39,15 @@ jobs:
           yarn run typedoc src/Yuuko.ts --out ".temp/docs/$TAG_NAME" --readme none
           echo "- '$TAG_NAME'" >> .temp/_data/docs.yml
 
-          # Commit to the gh-pages branch
+          # Add generated files that start with underscores to Jekyll `include`
           cd .temp
+          UNDERSCORE_FILES=(docs/**/_*)
+          for file in "$UNDERSCORES_FILE[@]"; do
+            # `include` is the last item of the config file, so we just append
+            echo "- '$file'" >> .config.yml
+          done
+
+          # Commit to the gh-pages branch
           git config user.name "Build Bot"
           git config user.email "bot@github-actions"
           git add docs _data


### PR DESCRIPTION
If Typedoc generates docs files that start with underscores, Jekyll ignores them by default because it ignores all files and folders that start with underscores. Jekyll's `include` config key can be used to get around this, but it doesn't support glob patterns - only individual files. To work around this, the doc gen script manually adds all underscored files in the generated docs to the `include` option when pushing the new docs version.