### PR TITLE
Add filename prop to errors thrown in addFile

### DIFF
--- a/src/Client.ts
+++ b/src/Client.ts
@@ -323,12 +323,18 @@ export class Client extends Eris.Client implements ClientOptions {
 			delete thing.default;
 		}
 		thing.filename = filename;
-		if (thing instanceof Command) {
-			this.addCommand(thing);
-		} else if (thing instanceof EventListener) {
-			this.addEvent(thing);
-		} else {
-			throw new TypeError('Exported value is not a command or event listener');
+		try {
+			if (thing instanceof Command) {
+				this.addCommand(thing);
+			} else if (thing instanceof EventListener) {
+				this.addEvent(thing);
+			} else {
+				throw new TypeError('Exported value is not a command or event listener');
+			}
+		} catch (error) {
+			// Add filename to errors and re-throw
+			error.filename = filename;
+			throw error;
 		}
 		return this;
 	}


### PR DESCRIPTION
Fixes #64. Adds a `filename` property to errors thrown when calling `addFile` (and by extension `addDir`). Node seems to display custom error properties when thrown, so we don't need to customize the message or anything.