### PR TITLE
Add helpers for creating commands with help info

### DIFF
--- a/src/Command.ts
+++ b/src/Command.ts
@@ -103,10 +103,8 @@ export interface CommandProcess<T extends Eris.Textable = Eris.TextableChannel> 
 	): void;
 }
 
-// These are slightly silly but they work. Not exposed because there's probably
-// a cleaner way to do this, so hopefully they won't be around for long.
-type GuildCommandProcess = CommandProcess<Eris.GuildTextableChannel>;
-type PrivateCommandProcess = CommandProcess<Eris.PrivateChannel>;
+export type GuildCommandProcess = CommandProcess<Eris.GuildTextableChannel>;
+export type PrivateCommandProcess = CommandProcess<Eris.PrivateChannel>;
 
 /** Class representing a command. */
 export class Command {


### PR DESCRIPTION
Fixes #72. Adds a `CommandWithHelp` class exported from the default help command that you can use in Typescript (or Javascript for that matter) to attach help info to commands more ergonomically. This is all contained in the default help command file since I don't really want to prescribe this as the only way to do a help command, so I'm not including it in the main library. Maybe eventually I should split some of those helpers off into their own thing...