### PR TITLE
Emit deprecation warnings

### DIFF
--- a/src/Client.ts
+++ b/src/Client.ts
@@ -7,6 +7,7 @@ import {Command, CommandRequirements, CommandContext} from './Command';
 import {EventListener, EventContext} from './EventListener';
 import defaultMessageListener from './defaultMessageListener';
 import {Resolves, makeArray} from './util';
+import * as deprecations from './deprecations';
 
 /** The options passed to the client constructor. Includes Eris options. */
 export interface ClientOptions extends Eris.ClientOptions {
@@ -32,6 +33,7 @@ export interface ClientOptions extends Eris.ClientOptions {
 	 * If true, requirements set via the globalCommandRequirements option will
 	 * be ignored.
 	 * @deprecated Pass no `globalCommandRequirements` client option instead.
+	 * See https://github.com/eritbh/yuuko/issues/89
 	*/
 	ignoreGlobalRequirements?: boolean;
 	/**
@@ -45,7 +47,8 @@ export interface ClientOptions extends Eris.ClientOptions {
 
 /**
  * Information returned from the API about the bot's OAuth application.
- * @deprecated Use `Eris.OAuthApplicationInfo` instead (this is a direct alias)
+ * @deprecated Use `Eris.OAuthApplicationInfo` instead. See
+ * https://github.com/eritbh/yuuko/issues/91
  */
 export type ClientOAuthApplication = Eris.OAuthApplicationInfo;
 
@@ -86,6 +89,7 @@ export class Client extends Eris.Client implements ClientOptions {
 	 * If true, requirements set via `setGlobalRequirements` will be ignored. Used
 	 * for debugging, probably shouldn't be used in production.
 	 * @deprecated Pass no `globalCommandRequirements` client option instead.
+	 * See https://github.com/eritbh/yuuko/issues/89
 	 */
 	ignoreGlobalRequirements: boolean = false;
 
@@ -141,7 +145,10 @@ export class Client extends Eris.Client implements ClientOptions {
 		if (options.allowMention !== undefined) this.allowMention = options.allowMention;
 		if (options.ignoreBots !== undefined) this.ignoreBots = options.ignoreBots;
 		if (options.globalCommandRequirements !== undefined) this.globalCommandRequirements = options.globalCommandRequirements;
-		if (options.ignoreGlobalRequirements !== undefined) this.ignoreGlobalRequirements = options.ignoreGlobalRequirements;
+		if (options.ignoreGlobalRequirements !== undefined) {
+			deprecations.ignoreGlobalRequirements();
+			this.ignoreGlobalRequirements = options.ignoreGlobalRequirements;
+		}
 		if (options.disableDefaultMessageListener !== undefined) this.disableDefaultMessageListener = options.disableDefaultMessageListener;
 
 		// Warn if we're using an empty prefix
@@ -242,8 +249,10 @@ export class Client extends Eris.Client implements ClientOptions {
 	/**
 	 * Set requirements for all commands at once
 	 * @deprecated Use the `globalCommandRequirements` client option instead.
+	 * See https://github.com/eritbh/yuuko/issues/89
 	 */
 	setGlobalRequirements (requirements: CommandRequirements) {
+		deprecations.setGlobalRequirements();
 		Object.assign(this.globalCommandRequirements, requirements);
 		return this;
 	}
@@ -406,25 +415,29 @@ export class Client extends Eris.Client implements ClientOptions {
 
 	/**
 	 * Alias for `addDir`.
-	 * @deprecated
+	 * @deprecated Use `addDir` instead. See
+	 * https://github.com/eritbh/yuuko/issues/88
 	 */
 	addCommandDir (dirname: string): this {
+		deprecations.addCommandDir();
 		return this.addDir(dirname);
 	}
 
 	/**
 	 * Alias for `addFile`.
-	 * @deprecated
+	 * @deprecated Use `addFile` instead. See https://github.com/eritbh/yuuko/issues/88
 	 */
 	addCommandFile (filename: string): this {
+		deprecations.addCommandFile();
 		return this.addFile(filename);
 	}
 
 	/**
 	 * Alias for `reloadFiles()`.
-	 * @deprecated
+	 * @deprecated Use `reloadFiles` instead. See https://github.com/eritbh/yuuko/issues/88
 	 */
 	reloadCommands (): this {
+		deprecations.reloadCommands();
 		return this.reloadFiles();
 	}
 
@@ -496,12 +509,18 @@ export class Client extends Eris.Client implements ClientOptions {
 		return null;
 	}
 
-	/** @deprecated Alias of `prefix` */
+	/**
+	 * Alias of `prefix`.
+	 * @deprecated Use `prefix` instead.
+	 * See https://github.com/eritbh/yuuko/issues/90
+	 */
 	get defaultPrefix () {
+		deprecations.defaultPrefix();
 		return this.prefix;
 	}
 
 	set defaultPrefix (val: string) {
+		deprecations.defaultPrefix();
 		this.prefix = val;
 	}
 }

--- a/src/deprecations.ts
+++ b/src/deprecations.ts
@@ -1,0 +1,22 @@
+import {emitWarning} from 'process';
+
+function warningEmitter (warning, code) {
+	let hasWarned = false;
+	return () => {
+		if (hasWarned) return;
+		hasWarned = true;
+		emitWarning(warning, 'DeprecationWarning', code);
+	};
+}
+
+// https://github.com/eritbh/yuuko/issues/88
+export const addCommandDir = warningEmitter('Client#addCommandDir is deprecated. Use Client#addDir instead.', 'yuuko#88');
+export const addCommandFile = warningEmitter('Client#addCommandFile is deprecated. Use Client#addFile instead.', 'yuuko#88');
+export const reloadCommands = warningEmitter('Client#reloadCommands is deprecated. Use Client#reloadFiles instead.', 'yuuko#88');
+
+// https://github.com/eritbh/yuuko/issues/89
+export const setGlobalRequirements = warningEmitter('Client#setGlobalRequirements is deprecated. Use the globalCommandRequirements client option instead.', 'yuuko#89');
+export const ignoreGlobalRequirements = warningEmitter('The ignoreGlobalRequirements client option is deprecated. Pass no globalCommandRequirements client option instead.', 'yuuko#89');
+
+// https://github.com/eritbh/yuuko/issues/90
+export const defaultPrefix = warningEmitter('Client#edfaultPrefix is deprecated. Use Client#prefix instead.', 'yuuko#90');


### PR DESCRIPTION
Fixes #78. Deprecated features now have dedicated issues describing upgrade paths and background. When using a deprecated feature, where possible, a Node process warning is emitted to notify the user of the deprecation. The warning code is a reference to the issue where the user can find more information about the deprecation. These issues are also linked in doc comments, so they're accessible from Intellisense and other static analysis tools.

If warning messages are not desired, Node can be run with the `--no-warnings` flag to disable their console messages. See [the Node.js process warning event docs](https://nodejs.org/docs/latest-v16.x/api/process.html#process_event_warning) for more information.