### PR TITLE
Options-first Command and EventListener constructors

### DIFF
--- a/src/Command.ts
+++ b/src/Command.ts
@@ -116,7 +116,7 @@ export class Command {
 	names: string[];
 
 	/** The function executed when the command is triggered. */
-	process: CommandProcess | GuildCommandProcess | PrivateCommandProcess
+	process: CommandProcess;
 
 	/** The requirements for the command being triggered. */
 	requirements: CommandRequirements;
@@ -127,13 +127,19 @@ export class Command {
 	/** Subcommands of this command. */
 	subcommands: Command[] = [];
 
-	// For some reason, I cannot get TS to recognize that `CommandProcess` is a
-	// superset of `GuildCommandProcess` and `PrivateCommandProcess`, so for
-	// now we have one more override than we should really need. Oh well.
-	// TODO: Does microsoft/typescript#31023 fix this?
-	constructor(names: string | string[], process: CommandProcess, requirements?: CommandRequirements);
-	constructor(names: string | string[], process: GuildCommandProcess, requirements: CommandRequirements & { guildOnly: true; dmOnly?: false });
-	constructor(names: string | string[], process: PrivateCommandProcess, requirements: CommandRequirements & { dmOnly: true; guildOnly?: false })
+	/** Creates a command restricted to use in guilds. */
+	constructor (names: string | string[], process: GuildCommandProcess, requirements: CommandRequirements & { guildOnly: true; dmOnly?: false });
+	/** Creates a command restricted to use in DMs. */
+	constructor (names: string | string[], process: PrivateCommandProcess, requirements: CommandRequirements & { dmOnly: true; guildOnly?: false });
+	/** Creates a command. */
+	constructor (names: string | string[], process: CommandProcess, requirements?: CommandRequirements);
+
+	/**
+	 * This implememtation signature is really messy to account for all the
+	 * different forms the constructor can take. It doesn't need to be exposed
+	 * in documentation or code suggestions.
+	 * @internal
+	 */
 	constructor (names: string | string[], process: CommandProcess | GuildCommandProcess | PrivateCommandProcess, requirements?: CommandRequirements) {
 		if (Array.isArray(names)) {
 			this.names = names;
@@ -141,8 +147,15 @@ export class Command {
 			this.names = [names];
 		}
 		if (!this.names[0]) throw new TypeError('At least one name is required');
-		this.process = process;
+
+		// NOTE: This cast discards away type information related to the
+		//       channels we expect this command to be executed in. The only
+		//       thing preventing e.g. private channel messages from being
+		//       passed to a guild-only command process are the runtime checks
+		//       in Command#execute below.
+		this.process = process as CommandProcess<Eris.TextableChannel>;
 		if (!this.process) throw new TypeError('Process is required');
+
 		this.requirements = {};
 		if (requirements) {
 			if (requirements.owner) {
@@ -210,10 +223,8 @@ export class Command {
 		// We have no subcommand, so call this command's process
 		// NOTE: By calling checkPermissions and returning early if it returns
 		//       false, we guarantee that messages will be the correct type for
-		//       the stored process, so this call is always safe. Restructuring
-		//       this to properly use TS type guards would be very messy and
-		//       would result in duplicate safety checks that we want to avoid.
-		// @ts-ignore
+		//       the stored process, even though we no longer have type info
+		//       about the process.
 		this.process(msg, args, ctx);
 		return true;
 	}


### PR DESCRIPTION
Fixes #96. Constructors for `Command` and `EventListener` currently take an optional object argument for additional options. However, because these both have required function arguments that can have long bodies, it can hurt readability to have options that impact how the function is run at the very bottom of the constructor, especially when working with single-file commands.

This PR adds support for passing the the object argument before the function argument in both these cases, and deprecates the signatures that put the function argument first. Signatures still exist to allow passing no object argument; both these constructors treat that case identically to passing an empty object.

- [x] Command constructor
- [ ] CommandWithHelp constructor
- [ ] EventListener constructor
- [ ] Migrate internal usage in default commands

<details>
<summary>what the deprecation will say</summary>

Deprecation: Object-last Client and EventListener constructor signatures

````
The `Command` and `EventListener` constructors both take an optional object argument containing additional options. #98 introduced new forms for these constructors, which place the options argument before the function argument, and deprecated the old forms which place the options argument at the end of the argument list.

Deprecated forms can be replaced by simply switching the position of the arguments, like so:

```js
// old
new Command('test', message => {
  // ...
}, {
  guildOnly: true,
  permissions: ['manageMessages'],
})
new EventListener('ready', () => {
  // ...
}, {once: true})

// new
new Command('test', {
  guildOnly: true,
  permissions: ['manageMessages'],
}, message => {
  // ...
})
new EventListener('ready', {once: true}, () => {
  // ...
})
```

Omitting the object argument entirely is still supported:

```js
new Command('ping', message => {
  // ...
})
new EventListener('messageCreate', message => {
  // ...
})
```

The object-last constructor signatures of `Command` and `EventListener` will be removed in the 3.0.0 release.
````

</details>