### PR TITLE
TextableChannel extends Textable now; build against eris 0.17.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
         "typescript": "4"
       },
       "peerDependencies": {
-        "eris": "*"
+        "eris": "^0.17.1"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -630,9 +630,9 @@
       }
     },
     "node_modules/eris": {
-      "version": "0.16.0",
-      "resolved": "https://registry.npmjs.org/eris/-/eris-0.16.0.tgz",
-      "integrity": "sha512-q46t8/6D88SLo20w29xycDvd67r9EpBOel/DKqRTfNms0XARPJpngITtFL9J6qRaRIkBr8PDeqpbO5gwNeSThw==",
+      "version": "0.17.1",
+      "resolved": "https://registry.npmjs.org/eris/-/eris-0.17.1.tgz",
+      "integrity": "sha512-PexpHusPxViuzcsSM0GQEAgZRJbziFfeeLifc8+ZrvS88UusPieQlUD7pRm28E7m7rN+p+Rt6bf9jGLwD725Zg==",
       "peer": true,
       "dependencies": {
         "ws": "^8.2.3"
@@ -2409,9 +2409,9 @@
       }
     },
     "eris": {
-      "version": "0.16.0",
-      "resolved": "https://registry.npmjs.org/eris/-/eris-0.16.0.tgz",
-      "integrity": "sha512-q46t8/6D88SLo20w29xycDvd67r9EpBOel/DKqRTfNms0XARPJpngITtFL9J6qRaRIkBr8PDeqpbO5gwNeSThw==",
+      "version": "0.17.1",
+      "resolved": "https://registry.npmjs.org/eris/-/eris-0.17.1.tgz",
+      "integrity": "sha512-PexpHusPxViuzcsSM0GQEAgZRJbziFfeeLifc8+ZrvS88UusPieQlUD7pRm28E7m7rN+p+Rt6bf9jGLwD725Zg==",
       "peer": true,
       "requires": {
         "opusscript": "^0.0.8",

--- a/src/Command.ts
+++ b/src/Command.ts
@@ -92,7 +92,6 @@ export interface CommandContext extends EventContext {
 }
 
 /** The function to be called when a command is executed. */
-// @ts-expect-error In Eris 0.16, TextableChannel is not assignable to Textable
 // See https://github.com/abalabahaha/eris/pull/1299
 export interface CommandProcess<T extends Eris.Textable = Eris.TextableChannel> {
 	(


### PR DESCRIPTION
Eris 0.17.0 fixes this issue that we had with 0.16.0; fixes the build against latest version of Eris